### PR TITLE
feat: Update commercial if it is also installed

### DIFF
--- a/Services/ProjectComposerJsonUpdater.php
+++ b/Services/ProjectComposerJsonUpdater.php
@@ -56,6 +56,12 @@ class ProjectComposerJsonUpdater
             $composerJson['require'][$shopwarePackage] = $version;
         }
 
+        if (isset($composerJson['require']['shopware/commercial'])) {
+            // If commercial is installed, also update it directly as part of the core update to keep them in sync
+            // Remove leading "(v)6." from Shopware version to match commercial release versions
+            $composerJson['require']['shopware/commercial'] = substr($version, strpos($version, '.') + 1);
+        }
+
         $composerJson = $this->configureRepositories($composerJson);
 
         file_put_contents($file, json_encode($composerJson, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));

--- a/Tests/Services/ProjectComposerJsonUpdaterTest.php
+++ b/Tests/Services/ProjectComposerJsonUpdaterTest.php
@@ -149,6 +149,33 @@ class ProjectComposerJsonUpdaterTest extends TestCase
         );
     }
 
+    public function testUpdateWithCommercialRequirement(): void
+    {
+        file_put_contents($this->json, json_encode([
+            'require' => [
+                'shopware/core' => '1.2.3',
+                'shopware/commercial' => '1.2.3',
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        (new ProjectComposerJsonUpdater(new MockHttpClient([$this->getEmptyVersionsResponse()])))->update(
+            $this->json,
+            '6.7.6.0'
+        );
+
+        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(
+            [
+                'require' => [
+                    'shopware/core' => '6.7.6.0',
+                    'shopware/commercial' => '7.6.0',
+                ],
+            ],
+            $composerJson
+        );
+    }
+
     public function testUpdateWithSymfonyRuntimeRequirement(): void
     {
         file_put_contents($this->json, json_encode([


### PR DESCRIPTION
Currently commercial has a too broad upper version constraint, which could lead to errors like this: https://github.com/shopware/shopware/issues/12229

Before the version of commercial was in sync with the SW version. meaning SW 6.7.6.0 -> commercial 7.6.0
no other minor version of commercial was allowed to be installed with SW 6.7.6.0.
This did not work good in update cases as you can get in a state where you have installed a non-compatible version of commercial. Therefore the broad upper boundary was introduced. 

As preparation to re-introduce the in-sync versions again, the web installer needs a change. The idea is to update Shopware and Commercial simultaneously. updating not only the core packages in the composer.json but also the commercial version. 

This only works, if we always tag a commercial release, when a Shopware release tag is created. @mkraeml please confirm this assumption :slightly_smiling_face: 

