### PR TITLE
fix: Do not forward query string to child processes

### DIFF
--- a/Services/StreamedCommandResponseGenerator.php
+++ b/Services/StreamedCommandResponseGenerator.php
@@ -23,7 +23,13 @@ class StreamedCommandResponseGenerator
     public function run(array $params, callable $finish): StreamedResponse
     {
         $process = new Process($params);
-        $process->setEnv(['COMPOSER_HOME' => sys_get_temp_dir() . '/composer']);
+        /** @phpstan-ignore-next-line False prevents Symfony Process from forwarding inherited environment variables. */
+        $process->setEnv([
+            'COMPOSER_HOME' => sys_get_temp_dir() . '/composer',
+            // The installer starts CLI commands from a web request. Symfony Runtime
+            // 7.4.12+ clears argv when QUERY_STRING is present, so do not forward it.
+            'QUERY_STRING' => false,
+        ]);
 
         // Read process timeout from environment or use default value
         $timeout = Platform::getEnv('SHOPWARE_INSTALLER_TIMEOUT');

--- a/Tests/Services/StreamedCommandResponseGeneratorTest.php
+++ b/Tests/Services/StreamedCommandResponseGeneratorTest.php
@@ -41,6 +41,30 @@ class StreamedCommandResponseGeneratorTest extends TestCase
         static::assertSame('foo' . \PHP_EOL . '{"success":true}', $content);
     }
 
+    public function testRunJSONDoesNotForwardQueryStringToChildProcesses(): void
+    {
+        $_SERVER['QUERY_STRING'] = 'shopwareVersion=6.7.9999999.9999999';
+        $_ENV['QUERY_STRING'] = 'shopwareVersion=6.7.9999999.9999999';
+        putenv('QUERY_STRING=shopwareVersion=6.7.9999999.9999999');
+
+        try {
+            $response = (new StreamedCommandResponseGenerator())->runJSON([
+                \PHP_BINARY,
+                '-r',
+                'echo getenv("QUERY_STRING") === false ? "clean" : "leaked";',
+            ]);
+
+            ob_start();
+            $response->sendContent();
+            $content = ob_get_clean();
+
+            static::assertSame('clean{"success":true}', $content);
+        } finally {
+            unset($_SERVER['QUERY_STRING'], $_ENV['QUERY_STRING']);
+            putenv('QUERY_STRING');
+        }
+    }
+
     public function testCustomTimeoutFromEnv(): void
     {
         $customTimeout = 333.0;


### PR DESCRIPTION
## What changed

- Prevent installer-spawned child processes from inheriting `QUERY_STRING`.
- Add a regression test that simulates the installer web request environment and verifies `QUERY_STRING` is not visible in a spawned PHP child process.

## Why

Symfony Runtime 7.4.12 changed argv handling for security hardening and clears CLI argv whenever `QUERY_STRING` is present. The web-installer starts Shopware console commands such as `system:update:prepare` and `system:update:finish` from a web request. If `QUERY_STRING` leaks into the child process environment, those commands are effectively executed as plain `bin/console`, which exits successfully after printing the command list.

That leaves update finalization incomplete: Composer has updated the Shopware packages, but assets are not installed, so the Administration can render a new Vite asset hash that does not exist in `public/bundles`. This showed up in shopware/shopware#16910 as acceptance update failures after the Symfony 7.4.12 release.

## Validation

- `vendor/bin/phpunit Tests/Services/StreamedCommandResponseGeneratorTest.php`
- `composer cs:check`
- `vendor/bin/phpstan analyse --memory-limit=1G`