### PR TITLE
docs: recommend shopware-cli as the preferred installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!IMPORTANT]
+> **The recommended way to install Shopware is [shopware-cli](https://github.com/shopware/shopware-cli)** —
+> a fully-featured CLI for installing, managing and developing with Shopware.
+> Our primary focus is on Shopware CLI and we do not plan to invest significant time in the web installer going forward.
+
 # Web Installer
 
 The web installer is a simple Symfony application packaged as a Phar file, that allows running automated Composer commands to install or update Shopware.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 > [!IMPORTANT]
 > **The recommended way to install Shopware is [Shopware CLI](https://github.com/shopware/shopware-cli)**, which provides
-> workflows for installing, managing, and developing Shopware projects and terminal user interface workflows.
-> Shopware CLI is our primary installation method and the focus of our ongoing development.
+> workflows for installing, managing, and developing Shopware projects, including an interactive terminal interface. See the [installation guide](https://developer.shopware.com/)
+> to get started.
+> 
+> Shopware CLI is our primary installation method and the focus of our ongoing development. Among other features, it provides an [upgrade wizard](https://developer.shopware.com/docs/products/tools/cli/project-commands/upgrade.html) for Shopware projects.
 >
 > The web installer will continue to be available, but will receive limited development going forward.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 > [!IMPORTANT]
-> **The recommended way to install Shopware is [shopware-cli](https://github.com/shopware/shopware-cli)** —
-> a fully-featured CLI for installing, managing and developing with Shopware.
-> Our primary focus is on Shopware CLI and we do not plan to invest significant time in the web installer going forward.
+> **The recommended way to install Shopware is [Shopware CLI](https://github.com/shopware/shopware-cli)**, which provides
+> workflows for installing, managing, and developing Shopware projects and terminal user interface workflows.
+> Shopware CLI is our primary installation method and the focus of our ongoing development.
+>
+> The web installer will continue to be available, but will receive limited development going forward.
 
 # Web Installer
 


### PR DESCRIPTION
Adds a note to the README pointing users to shopware-cli as the recommended way to install Shopware.