### PR TITLE
Improve installer template testability (accessibility-first)

### DIFF
--- a/Resources/views/install.html.twig
+++ b/Resources/views/install.html.twig
@@ -35,7 +35,7 @@
         <div class="alert alert-error" id="log-error" style="display: none">{{ 'shopware.update.steps.install.error'|trans|raw }}</div>
 
         <div id="log-card" style="display: none;">
-            <pre class="form-control" id="log-output" style="height: 60vh;"></pre>
+            <pre class="form-control" id="log-output" style="height: 60vh;" data-testid="install-log-output"></pre>
         </div>
 
     </div>

--- a/Resources/views/php_config.html.twig
+++ b/Resources/views/php_config.html.twig
@@ -10,8 +10,8 @@
 
         <form method="POST" id="submit">
             <div class="form-group">
-                <label for="name">{{ 'shopware.update.steps.configure_php.pathInput'|trans }}</label>
-                <input class="form-control" type="text" name="phpBinary" value="{{ phpBinary }}">
+                <label for="phpBinary">{{ 'shopware.update.steps.configure_php.pathInput'|trans }}</label>
+                <input class="form-control" type="text" id="phpBinary" name="phpBinary" value="{{ phpBinary }}">
             </div>
         </form>
     </div>

--- a/Resources/views/update.html.twig
+++ b/Resources/views/update.html.twig
@@ -31,7 +31,7 @@
             <div class="card-body">
                 <h5 class="card-title">{{ 'shopware.update.steps.update.log'|trans }}</h5>
 
-                <pre class="form-control" id="log-output" style="height: 60vh"></pre>
+                <pre class="form-control" id="log-output" style="height: 60vh" data-testid="update-log-output"></pre>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What

Make the installer reliably targetable from acceptance tests, **preferring accessible locators** (`getByRole` / `getByLabel` / `getByText`) over test-only hooks and adding `data-testid` only where no accessible handle exists.

## Changes

| File | Change | Rationale |
|---|---|---|
| `php_config.html.twig` | Fix the PHP-binary field's label association (`<label for="name">` → `for="phpBinary"`, add matching `id` to the input) | The `for` pointed at a non-existent id, so `getByLabel('PHP binary')` didn't work. Fixing accessibility is preferred over adding a test id. |
| `install.html.twig` | `data-testid="install-log-output"` on the log `<pre>` | A streamed-log `<pre>` has no role, accessible name or stable text — it can't be located accessibly. |
| `update.html.twig` | `data-testid="update-log-output"` on the log `<pre>` | Same as above. |

Everything else in the installer (buttons, links, headings, labeled selects, visible text, alerts) is already reachable via role/label/text locators, so **no** test ids were added there.

## Notes

- Net change is 3 files / 4 lines; no Twig logic touched.
- All 85 existing PHPUnit tests pass (256 assertions).
- No companion change is needed in `shopware/shopware`: the acceptance suite's `Update.spec.ts` already uses accessible `getByRole` locators for this installer's steps (Continue / Update Shopware / Finish / Open Administration), and those remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJMFV7jMT6L1Re9DPQtfwF