### PR TITLE
Register shopware/conflicts composer repository on install and update

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -105,6 +105,8 @@ jobs:
           jq '.config.audit = { "block-insecure": false }' composer.json > composer.json.new
           mv composer.json.new composer.json
 
+          composer config repositories.shopware-conflicts composer https://shopware.github.io/conflicts/
+
           composer require shopware/core:${{ matrix.update.version }}
 
       - name: Install

--- a/Resources/install-template/composer.json
+++ b/Resources/install-template/composer.json
@@ -32,6 +32,10 @@
             "options": {
                 "symlink": true
             }
+        },
+        {
+            "type": "composer",
+            "url": "https://shopware.github.io/conflicts/"
         }
     ],
     "minimum-stability": "RC",

--- a/Services/ProjectComposerJsonUpdater.php
+++ b/Services/ProjectComposerJsonUpdater.php
@@ -56,6 +56,7 @@ class ProjectComposerJsonUpdater
             $composerJson['require'][$shopwarePackage] = $version;
         }
 
+        $composerJson = $this->ensureConflictsRepository($composerJson);
         $composerJson = $this->configureRepositories($composerJson);
 
         file_put_contents($file, json_encode($composerJson, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
@@ -78,6 +79,44 @@ class ProjectComposerJsonUpdater
         }
 
         return $latestVersion;
+    }
+
+    /**
+     * Ensures the shopware/conflicts composer repository is registered so the
+     * shopware/conflicts package can be resolved during install and update.
+     *
+     * @see https://github.com/shopware/conflicts/blob/main/USAGES.md
+     *
+     * @param array<mixed> $config
+     *
+     * @return array<mixed>
+     */
+    private function ensureConflictsRepository(array $config): array
+    {
+        if (!isset($config['repositories'])) {
+            $config['repositories'] = [];
+        }
+
+        $repositories = $config['repositories'];
+
+        foreach ($repositories as $repository) {
+            if (!\is_array($repository)) {
+                continue;
+            }
+
+            if (($repository['url'] ?? null) === 'https://shopware.github.io/conflicts/') {
+                return $config;
+            }
+        }
+
+        $repositories['shopware-conflicts'] = [
+            'type' => 'composer',
+            'url' => 'https://shopware.github.io/conflicts/',
+        ];
+
+        $config['repositories'] = $repositories;
+
+        return $config;
     }
 
     /**

--- a/Services/ProjectComposerJsonUpdater.php
+++ b/Services/ProjectComposerJsonUpdater.php
@@ -85,6 +85,10 @@ class ProjectComposerJsonUpdater
      * Ensures the shopware/conflicts composer repository is registered so the
      * shopware/conflicts package can be resolved during install and update.
      *
+     * Existing `repositories` layouts are preserved: an indexed list stays a
+     * list and a keyed map stays a map. If the conflicts repository is already
+     * present (matched by URL) it is left untouched.
+     *
      * @see https://github.com/shopware/conflicts/blob/main/USAGES.md
      *
      * @param array<mixed> $config
@@ -93,28 +97,20 @@ class ProjectComposerJsonUpdater
      */
     private function ensureConflictsRepository(array $config): array
     {
-        if (!isset($config['repositories'])) {
-            $config['repositories'] = [];
-        }
-
-        $repositories = $config['repositories'];
-
-        foreach ($repositories as $repository) {
-            if (!\is_array($repository)) {
-                continue;
-            }
-
-            if (($repository['url'] ?? null) === 'https://shopware.github.io/conflicts/') {
-                return $config;
-            }
-        }
-
-        $repositories['shopware-conflicts'] = [
+        $conflictsRepository = [
             'type' => 'composer',
             'url' => 'https://shopware.github.io/conflicts/',
         ];
 
-        $config['repositories'] = $repositories;
+        if ($this->hasRepository($config['repositories'] ?? [], $conflictsRepository['url'])) {
+            return $config;
+        }
+
+        $config['repositories'] = $this->addRepository(
+            $config['repositories'] ?? [],
+            'shopware-conflicts',
+            $conflictsRepository
+        );
 
         return $config;
     }
@@ -134,10 +130,56 @@ class ProjectComposerJsonUpdater
                 return $config;
             }
 
-            $config['repositories']['recovery'] = $repo;
+            $config['repositories'] = $this->addRepository(
+                $config['repositories'] ?? [],
+                'recovery',
+                $repo
+            );
         }
 
         return $config;
+    }
+
+    /**
+     * Returns true when a repository with the given URL is already registered,
+     * no matter whether `repositories` is an indexed list or a keyed map.
+     *
+     * @param array<mixed> $repositories
+     */
+    private function hasRepository(array $repositories, string $url): bool
+    {
+        foreach ($repositories as $repository) {
+            if (!\is_array($repository)) {
+                continue;
+            }
+
+            if (($repository['url'] ?? null) === $url) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Adds a repository entry while preserving the existing `repositories`
+     * structure: an indexed list stays a list (entry appended), a keyed map
+     * stays a map (entry added under `$name`).
+     *
+     * @param array<int|string, mixed>              $repositories
+     * @param array{type: string, url: string, ...} $repository
+     *
+     * @return array<int|string, mixed>
+     */
+    private function addRepository(array $repositories, string $name, array $repository): array
+    {
+        if (array_is_list($repositories)) {
+            $repositories[] = $repository;
+        } else {
+            $repositories[$name] = $repository;
+        }
+
+        return $repositories;
     }
 
     private function getConflictMinVersion(string $shopwareVersion): ?string

--- a/Tests/Services/ProjectComposerJsonUpdaterTest.php
+++ b/Tests/Services/ProjectComposerJsonUpdaterTest.php
@@ -51,7 +51,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => '6.4.18.0',
                 ],
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -77,7 +77,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 ],
                 'minimum-stability' => 'RC',
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -107,7 +107,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 ],
                 'minimum-stability' => 'RC',
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -138,7 +138,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 ],
                 'minimum-stability' => 'RC',
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -169,7 +169,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 ],
                 'minimum-stability' => 'RC',
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -202,7 +202,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'symfony/runtime' => '>=5',
                 ],
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -236,7 +236,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'symfony/runtime' => '>=5',
                 ],
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -270,7 +270,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/conflicts' => '>=2.0.0',
                 ],
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -304,7 +304,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/conflicts' => '>=1.0.0',
                 ],
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -338,7 +338,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/conflicts' => '>=1.0.0',
                 ],
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
@@ -378,11 +378,11 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 ],
                 'minimum-stability' => 'RC',
                 'repositories' => [
-                    'shopware-conflicts' => [
+                    [
                         'type' => 'composer',
                         'url' => 'https://shopware.github.io/conflicts/',
                     ],
-                    'recovery' => $customRepo,
+                    $customRepo,
                 ],
             ],
             $composerJson
@@ -416,6 +416,80 @@ class ProjectComposerJsonUpdaterTest extends TestCase
         static::assertSame(
             [
                 [
+                    'type' => 'composer',
+                    'url' => 'https://shopware.github.io/conflicts/',
+                ],
+            ],
+            $composerJson['repositories']
+        );
+    }
+
+    public function testConflictsRepositoryPreservesIndexedListForm(): void
+    {
+        $pathRepo = [
+            'type' => 'path',
+            'url' => 'custom/plugins/*',
+            'options' => ['symlink' => true],
+        ];
+
+        file_put_contents($this->json, json_encode([
+            'require' => [
+                'shopware/core' => '1.2.3',
+            ],
+            'repositories' => [
+                $pathRepo,
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        (new ProjectComposerJsonUpdater(new MockHttpClient([$this->getEmptyVersionsResponse()])))->update(
+            $this->json,
+            '6.4.18.0'
+        );
+
+        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+
+        // Existing list form is preserved; conflicts repo appended as a list item
+        static::assertSame(
+            [
+                $pathRepo,
+                [
+                    'type' => 'composer',
+                    'url' => 'https://shopware.github.io/conflicts/',
+                ],
+            ],
+            $composerJson['repositories']
+        );
+    }
+
+    public function testConflictsRepositoryPreservesKeyedMapForm(): void
+    {
+        $pathRepo = [
+            'type' => 'path',
+            'url' => 'custom/plugins/*',
+            'options' => ['symlink' => true],
+        ];
+
+        file_put_contents($this->json, json_encode([
+            'require' => [
+                'shopware/core' => '1.2.3',
+            ],
+            'repositories' => [
+                'plugins' => $pathRepo,
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        (new ProjectComposerJsonUpdater(new MockHttpClient([$this->getEmptyVersionsResponse()])))->update(
+            $this->json,
+            '6.4.18.0'
+        );
+
+        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+
+        // Existing keyed map form is preserved; conflicts repo added under a named key
+        static::assertSame(
+            [
+                'plugins' => $pathRepo,
+                'shopware-conflicts' => [
                     'type' => 'composer',
                     'url' => 'https://shopware.github.io/conflicts/',
                 ],

--- a/Tests/Services/ProjectComposerJsonUpdaterTest.php
+++ b/Tests/Services/ProjectComposerJsonUpdaterTest.php
@@ -50,6 +50,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 'require' => [
                     'shopware/core' => '6.4.18.0',
                 ],
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -70,6 +76,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => '6.4.18.0-rc1',
                 ],
                 'minimum-stability' => 'RC',
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -94,6 +106,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => 'dev-trunk as 6.5.0.0',
                 ],
                 'minimum-stability' => 'RC',
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -119,6 +137,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => 'main as 6.5.0.0',
                 ],
                 'minimum-stability' => 'RC',
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -144,6 +168,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => '6.5.0.0',
                 ],
                 'minimum-stability' => 'RC',
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -170,6 +200,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 'require' => [
                     'shopware/core' => '6.6.0.0',
                     'symfony/runtime' => '>=5',
+                ],
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
                 ],
             ],
             $composerJson
@@ -199,6 +235,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => '6.7.0.0',
                     'symfony/runtime' => '>=5',
                 ],
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -226,6 +268,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => '6.6.0.0',
                     'symfony/runtime' => '>=5',
                     'shopware/conflicts' => '>=2.0.0',
+                ],
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
                 ],
             ],
             $composerJson
@@ -255,6 +303,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'symfony/runtime' => '>=5',
                     'shopware/conflicts' => '>=1.0.0',
                 ],
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
+                ],
             ],
             $composerJson
         );
@@ -282,6 +336,12 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                     'shopware/core' => '6.4.0.0',
                     'symfony/runtime' => '>=5',
                     'shopware/conflicts' => '>=1.0.0',
+                ],
+                'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
                 ],
             ],
             $composerJson
@@ -318,10 +378,49 @@ class ProjectComposerJsonUpdaterTest extends TestCase
                 ],
                 'minimum-stability' => 'RC',
                 'repositories' => [
+                    'shopware-conflicts' => [
+                        'type' => 'composer',
+                        'url' => 'https://shopware.github.io/conflicts/',
+                    ],
                     'recovery' => $customRepo,
                 ],
             ],
             $composerJson
+        );
+    }
+
+    public function testUpdateKeepsExistingConflictsRepository(): void
+    {
+        $existingRepo = [
+            'type' => 'composer',
+            'url' => 'https://shopware.github.io/conflicts/',
+        ];
+
+        file_put_contents($this->json, json_encode([
+            'require' => [
+                'shopware/core' => '1.2.3',
+            ],
+            'repositories' => [
+                $existingRepo,
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        (new ProjectComposerJsonUpdater(new MockHttpClient([$this->getEmptyVersionsResponse()])))->update(
+            $this->json,
+            '6.4.18.0'
+        );
+
+        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+
+        // Existing conflicts repository is preserved and not duplicated
+        static::assertSame(
+            [
+                [
+                    'type' => 'composer',
+                    'url' => 'https://shopware.github.io/conflicts/',
+                ],
+            ],
+            $composerJson['repositories']
         );
     }
 


### PR DESCRIPTION
## What & why

This PR ensures `https://shopware.github.io/conflicts/` is registered as a Composer repository on **new installations** and on **updates**, so the `shopware/conflicts` package can always be resolved.

See the conflicts package usage docs: https://github.com/shopware/conflicts/blob/main/USAGES.md

## Changes

- `Resources/install-template/composer.json` — add the conflicts composer repository to the template that bootstraps new installations.
- `Services/ProjectComposerJsonUpdater.php` — new idempotent `ensureConflictsRepository()` method, called from `update()`. `update()` is the common choke point invoked by both `InstallController::run` (new installs, after the template is copied) and `UpdateController::run` (updates, against the existing project `composer.json` — including Flex projects where `FlexMigrator` is not invoked). The repo is matched by URL, so it is not duplicated whether existing `repositories` is an indexed list or a named map.
- `Tests/Services/ProjectComposerJsonUpdaterTest.php` — updated assertions to reflect the conflicts repository and added `testUpdateKeepsExistingConflictsRepository` to verify an already-present conflicts repo is preserved without duplication.

`FlexMigrator::patchRootComposerJson` is intentionally untouched: `ProjectComposerJsonUpdater::update()` runs in both flows, so adding the repo there covers all cases without duplicating logic and without perturbing the `FlexMigratorTest` symlink-repository expectations.

## Verification

- `vendor/bin/phpunit` → **86 tests, 257 assertions, OK**
- `vendor/bin/phpstan analyse` → **No errors**
- `vendor/bin/php-cs-fixer fix --dry-run` → **0 files to fix**
- Install template `composer.json` is valid JSON