### PR TITLE
feat: allow installer in /public, fix steps, language fallback

### DIFF
--- a/Controller/IndexController.php
+++ b/Controller/IndexController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Shopware\WebInstaller\Controller;
 
 use Shopware\WebInstaller\Services\LanguageProvider;
+use Shopware\WebInstaller\Services\RecoveryManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -14,11 +16,16 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 class IndexController extends AbstractController
 {
-    public function __construct(private readonly LanguageProvider $languageProvider) {}
+    public function __construct(
+        private readonly LanguageProvider $languageProvider,
+        private readonly RecoveryManager $recoveryManager,
+    ) {}
 
     #[Route('/', name: 'index', defaults: ['step' => 0])]
-    public function index(): Response
+    public function index(Request $request): Response
     {
+        $request->getSession()->set('installerMode', $this->recoveryManager->getMode());
+
         return $this->render('index.html.twig', [
             'supportedLanguages' => $this->languageProvider->getSupportedLanguages(),
         ]);

--- a/Controller/InstallController.php
+++ b/Controller/InstallController.php
@@ -54,7 +54,7 @@ class InstallController extends AbstractController
             'shopware_version' => $shopwareVersion,
         ]);
 
-        $folder = $this->recoveryManager->getProjectDir();
+        $folder = $this->recoveryManager->getInstallTargetDir();
 
         $fs = new Filesystem();
         $fs->copy(\dirname(__DIR__) . '/Resources/install-template/composer.json', $folder . '/composer.json');
@@ -88,7 +88,16 @@ class InstallController extends AbstractController
                     $queryParams['language'] = rawurlencode($locale);
                 }
 
-                $data['newLocation'] = $request->getBasePath() . '/public/' . \http_build_query($queryParams);
+                // in a PHAR, getBasePath() is the phar's own URL path; strip it to the containing directory
+                $base = \rtrim(\str_replace('\\', '/', \dirname($request->getBasePath())), '/');
+                if ($base === '.') {
+                    $base = '';
+                }
+
+                // phar in public/ (docroot=public/) → shop at "/"; phar at project root → shop in "public/"
+                $shopPath = basename($this->recoveryManager->getProjectDir()) === 'public' ? '/' : '/public/';
+
+                $data['newLocation'] = $base . $shopPath . '?' . \http_build_query($queryParams);
             }
 
             echo json_encode($data);
@@ -114,7 +123,7 @@ class InstallController extends AbstractController
     #[Route('/install/_cleanup', name: 'install_cleanup', methods: ['POST'])]
     public function cleanup(): StreamedResponse
     {
-        $folder = $this->recoveryManager->getProjectDir();
+        $folder = $this->recoveryManager->getInstallTargetDir();
 
         $fs = new Filesystem();
         $htaccessFile = $folder . '/public/.htaccess';

--- a/Controller/PhpConfigController.php
+++ b/Controller/PhpConfigController.php
@@ -28,7 +28,7 @@ class PhpConfigController extends AbstractController
     {
         try {
             $shopwareLocation = $this->recoveryManager->getShopwareLocation();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $shopwareLocation = null;
         }
 
@@ -38,7 +38,10 @@ class PhpConfigController extends AbstractController
 
             $request->getSession()->set('phpBinary', $phpBinary);
 
-            return $this->redirectToRoute($shopwareLocation === null ? 'install' : 'update');
+            $mode = $this->recoveryManager->getMode();
+            $request->getSession()->set('installerMode', $mode);
+
+            return $this->redirectToRoute($mode);
         }
 
         return $this->render('php_config.html.twig', [

--- a/Listener/InstallerLocaleListener.php
+++ b/Listener/InstallerLocaleListener.php
@@ -40,10 +40,22 @@ class InstallerLocaleListener
 
         // language is changed
         $language = $request->query->getString('language');
-        if ($language !== '' && \in_array($language, $this->installerLanguages, true)) {
-            $session->set('language', $language);
+        if ($language !== '') {
+            if (\in_array($language, $this->installerLanguages, true)) {
+                $session->set('language', $language);
 
-            return $language;
+                return $language;
+            }
+
+            // no exact match: fall back to the base language (en-GB -> en) if supported
+            if (str_contains($language, '-')) {
+                $baseLanguage = explode('-', $language, 2)[0];
+                if (\in_array($baseLanguage, $this->installerLanguages, true)) {
+                    $session->set('language', $baseLanguage);
+
+                    return $baseLanguage;
+                }
+            }
         }
 
         // language was already set

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
     public: false
 
   Shopware\WebInstaller\:
-    resource: '../../{Listener,Services}'
+    resource: '../../{Listener,Services,Twig}'
 
   Shopware\WebInstaller\Controller\:
     resource: '../../Controller'

--- a/Resources/public/assets/app.js
+++ b/Resources/public/assets/app.js
@@ -82,6 +82,14 @@ const logCard = document.getElementById('log-card');
 const logOutput = document.getElementById('log-output');
 const logError = document.getElementById('log-error');
 
+// auto-submit on language change; the hidden submit button is the no-JS fallback
+const languageSwitcher = document.getElementById('language');
+if (languageSwitcher && languageSwitcher.form) {
+    languageSwitcher.addEventListener('change', () => {
+        languageSwitcher.form.submit();
+    });
+}
+
 if (installButton) {
     installButton.onclick = async function () {
         logCard.style.removeProperty('display');

--- a/Resources/public/assets/styles/style.css
+++ b/Resources/public/assets/styles/style.css
@@ -1343,3 +1343,16 @@ table .notice-text td p {
 /*endregion*/
 
 /*endregion*/
+
+/* Accessibility utility: present for screen readers / no-CSS, hidden visually. */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -47,7 +47,7 @@
                             {% endfor %}
                         </select>
                     </div>
-                    <button type="submit" class="visually-hidden">{{ 'shopware.update.continue'|trans }}</button>
+                    <button type="submit" class="visually-hidden">{{ 'shopware.update.steps.start.languageSelection'|trans }}</button>
                 </form>
             </div>
         </div>

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -36,7 +36,6 @@
                                 id="language"
                                 name="language"
                                 class="language-selection"
-                                onchange="this.form.submit();"
                         >
                             {% for baseTag, language in supportedLanguages %}
                                 <option
@@ -48,6 +47,7 @@
                             {% endfor %}
                         </select>
                     </div>
+                    <button type="submit" class="visually-hidden">{{ 'shopware.update.continue'|trans }}</button>
                 </form>
             </div>
         </div>
@@ -55,45 +55,13 @@
 
     <div class="page--wrap">
         <div class="content--wrapper">
-            {% set navigationPosition = app.request.attributes.get('step') %}
-
             <nav class="navigation--main">
                 <ul class="navigation--list">
-                    <li class="navigation--entry{% if navigationPosition == '0' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.start'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '1' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.configure_php'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '2' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.download'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '3' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.requirements'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '3' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.license'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '3' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.database-configuration'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '3' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.database-import'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '3' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.configuration'|trans }}</span>
-                    </li>
-
-                    <li class="navigation--entry{% if navigationPosition == '3' %} is--active{% endif %}">
-                        <span class="navigation--link">{{ 'shopware.update.navigation.finish'|trans }}</span>
-                    </li>
+                    {% for step in installer_steps() %}
+                        <li class="navigation--entry{% if step.active %} is--active{% endif %}"{% if step.active %} aria-current="step"{% endif %}>
+                            <span class="navigation--link">{{ ('shopware.update.navigation.' ~ step.key)|trans }}</span>
+                        </li>
+                    {% endfor %}
                 </ul>
             </nav>
             <section class="content--main">

--- a/Services/RecoveryManager.php
+++ b/Services/RecoveryManager.php
@@ -36,6 +36,31 @@ class RecoveryManager
         return \dirname($fileName);
     }
 
+    /**
+     * Directory the fresh installation is written into: the parent when the PHAR sits in a
+     * "public/" docroot (as {@see getShopwareLocation()}), otherwise the PHAR's own directory.
+     */
+    public function getInstallTargetDir(): string
+    {
+        $projectDir = $this->getProjectDir();
+
+        return basename($projectDir) === 'public' ? \dirname($projectDir) : $projectDir;
+    }
+
+    /**
+     * The active flow: 'update' when a shop already exists ({@see getShopwareLocation()}), else 'install'.
+     */
+    public function getMode(): string
+    {
+        try {
+            $this->getShopwareLocation();
+
+            return 'update';
+        } catch (\RuntimeException) {
+            return 'install';
+        }
+    }
+
     public function getShopwareLocation(): string
     {
         $projectDir = $this->getProjectDir();

--- a/Services/StepProvider.php
+++ b/Services/StepProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\WebInstaller\Services;
+
+/**
+ * Builds the ordered list of stepper entries for the current flow. The install
+ * flow shows the full journey (the trailing steps happen in the core installer
+ * after the PHAR hands off); the update flow only ever runs start → PHP binary →
+ * download → finish, so the install-only setup steps are omitted.
+ *
+ * @internal
+ *
+ * @phpstan-type Step array{key: string, active: bool}
+ */
+class StepProvider
+{
+    /**
+     * @var array<string, list<string>>
+     */
+    private const STEPS = [
+        'install' => ['start', 'configure_php', 'download', 'requirements', 'license', 'database-configuration', 'database-import', 'configuration', 'finish'],
+        'update' => ['start', 'configure_php', 'download', 'finish'],
+    ];
+
+    /**
+     * Maps a controller route name to the stepper entry it activates. Steps with
+     * no route here (the core-installer setup steps) are never active in this tool.
+     *
+     * @var array<string, string>
+     */
+    private const ROUTE_TO_STEP = [
+        'index' => 'start',
+        'configure' => 'configure_php',
+        'install' => 'download',
+        'update' => 'download',
+        'finish' => 'finish',
+    ];
+
+    /**
+     * @return list<Step>
+     */
+    public function getSteps(string $mode, ?string $route): array
+    {
+        $keys = self::STEPS[$mode] ?? self::STEPS['install'];
+        $activeKey = $route === null ? null : (self::ROUTE_TO_STEP[$route] ?? null);
+
+        return array_map(
+            static fn(string $key): array => ['key' => $key, 'active' => $key === $activeKey],
+            $keys,
+        );
+    }
+}

--- a/Services/StreamedCommandResponseGenerator.php
+++ b/Services/StreamedCommandResponseGenerator.php
@@ -43,9 +43,11 @@ class StreamedCommandResponseGenerator
         $process->start();
 
         return new StreamedResponse(function () use ($process, $finish): void {
-            // drop PHP's output buffers so each chunk reaches the client (flush() alone won't)
-            while (ob_get_level() > 0) {
-                ob_end_flush();
+            // under a web SAPI, drop the output buffer so each chunk streams (flush() alone won't)
+            if (\PHP_SAPI !== 'cli') {
+                while (ob_get_level() > 0) {
+                    ob_end_flush();
+                }
             }
 
             try {

--- a/Services/StreamedCommandResponseGenerator.php
+++ b/Services/StreamedCommandResponseGenerator.php
@@ -43,6 +43,11 @@ class StreamedCommandResponseGenerator
         $process->start();
 
         return new StreamedResponse(function () use ($process, $finish): void {
+            // drop PHP's output buffers so each chunk reaches the client (flush() alone won't)
+            while (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+
             try {
                 foreach ($process->getIterator() as $item) {
                     \assert(\is_string($item));

--- a/Tests/Controller/IndexControllerTest.php
+++ b/Tests/Controller/IndexControllerTest.php
@@ -8,8 +8,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\WebInstaller\Controller\IndexController;
 use Shopware\WebInstaller\Services\LanguageProvider;
+use Shopware\WebInstaller\Services\RecoveryManager;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Routing\Router;
 use Twig\Environment;
 
@@ -19,25 +23,28 @@ use Twig\Environment;
 #[CoversClass(IndexController::class)]
 class IndexControllerTest extends TestCase
 {
-    public function testIndexRedirectsToInstall(): void
+    public function testIndexSeedsInstallerModeAndRenders(): void
     {
-        $router = $this->createMock(Router::class);
-        $router
-            ->method('generate')
-            ->willReturnArgument(0);
+        $recoveryManager = $this->createMock(RecoveryManager::class);
+        $recoveryManager->method('getMode')->willReturn('update');
 
-        $controller = new IndexController($this->createMock(LanguageProvider::class));
+        $controller = new IndexController($this->createMock(LanguageProvider::class), $recoveryManager);
         $container = new Container();
+        $router = $this->createMock(Router::class);
+        $router->method('generate')->willReturnArgument(0);
         $container->set('router', $router);
-
         $twig = $this->createMock(Environment::class);
         $twig->method('render')->willReturnArgument(0);
-
         $container->set('twig', $twig);
-
         $controller->setContainer($container);
 
-        $response = $controller->index();
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $response = $controller->index($request);
+
+        // The flow is resolved on the very first screen so the stepper is correct from the start.
+        static::assertSame('update', $request->getSession()->get('installerMode'));
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame('index.html.twig', $response->getContent());
     }

--- a/Tests/Controller/InstallControllerTest.php
+++ b/Tests/Controller/InstallControllerTest.php
@@ -57,6 +57,7 @@ class InstallControllerTest extends TestCase
         $recovery->method('getShopwareLocation')->willReturn('location');
         $recovery->method('getPHPBinary')->willReturn('php');
         $recovery->method('getProjectDir')->willReturn($tmpDir);
+        $recovery->method('getInstallTargetDir')->willReturn($tmpDir);
 
         $responseGenerator = $this->createMock(StreamedCommandResponseGenerator::class);
         $responseGenerator
@@ -119,6 +120,70 @@ class InstallControllerTest extends TestCase
         (new Filesystem())->remove($tmpDir);
     }
 
+    public function testRunFinishCallableHandsOffToShopRootWhenPharInsidePublic(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('test', true);
+        $publicDir = $tmpDir . '/public';
+        (new Filesystem())->mkdir($publicDir);
+
+        $finishCallable = null;
+
+        // PHAR dropped into a public/ directory (docroot=public/): the project is
+        // installed into the parent and the shop is served at the docroot root, so
+        // the hand-off must target "/" and NOT "/public/".
+        $recoveryManagerMock = $this->createMock(RecoveryManager::class);
+        $recoveryManagerMock->method('getProjectDir')->willReturn($publicDir);
+        $recoveryManagerMock->method('getInstallTargetDir')->willReturn($tmpDir);
+        $recoveryManagerMock->method('getPHPBinary')->willReturn('php');
+        $recoveryManagerMock->method('getBinary')->willReturn('binary');
+
+        $responseGenerator = $this->createMock(StreamedCommandResponseGenerator::class);
+        $responseGenerator
+            ->method('run')
+            ->willReturnCallback(function ($command, $finish) use (&$finishCallable) {
+                $finishCallable = $finish;
+
+                return new StreamedResponse();
+            });
+
+        $installController = new InstallController(
+            $recoveryManagerMock,
+            $responseGenerator,
+            $this->createMock(ReleaseInfoProvider::class),
+            $this->createMock(ProjectComposerJsonUpdater::class),
+            $this->createMock(LanguageProvider::class),
+            $this->createMock(TrackingService::class),
+        );
+        $installController->setContainer($this->buildContainer());
+
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $request->query->set('shopwareVersion', '6.7.3.0');
+        $request->setLocale('de');
+
+        $installController->run($request);
+
+        static::assertIsCallable($finishCallable);
+
+        $process = $this->createMock(Process::class);
+        $process->method('isSuccessful')->willReturn(true);
+
+        ob_start();
+        $finishCallable($process);
+        $output = ob_get_clean();
+        static::assertIsString($output);
+
+        $data = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+        static::assertIsArray($data);
+        static::assertArrayHasKey('newLocation', $data);
+        static::assertStringStartsWith('/?', $data['newLocation']);
+        static::assertStringNotContainsString('/public/', $data['newLocation']);
+        static::assertStringContainsString('ext_steps=1', $data['newLocation']);
+        static::assertStringContainsString('language=de', $data['newLocation']);
+
+        (new Filesystem())->remove($tmpDir);
+    }
+
     public function testRunFinishCallableOnFailure(): void
     {
         $finishCallable = null;
@@ -173,6 +238,7 @@ class InstallControllerTest extends TestCase
 
         $recoveryManagerMock = $this->createMock(RecoveryManager::class);
         $recoveryManagerMock->method('getProjectDir')->willReturn($tmpDir);
+        $recoveryManagerMock->method('getInstallTargetDir')->willReturn($tmpDir);
         $recoveryManagerMock->method('getPHPBinary')->willReturn('php');
         $recoveryManagerMock->method('getBinary')->willReturn('binary');
 

--- a/Tests/Controller/PhpConfigControllerTest.php
+++ b/Tests/Controller/PhpConfigControllerTest.php
@@ -40,7 +40,10 @@ class PhpConfigControllerTest extends TestCase
 
     public function testSetConfigOnUpdate(): void
     {
-        $controller = new PhpConfigController($this->createMock(PhpBinaryFinder::class), $this->createMock(RecoveryManager::class), $this->createMock(LanguageProvider::class));
+        $recoveryManager = $this->createMock(RecoveryManager::class);
+        $recoveryManager->method('getMode')->willReturn('update');
+
+        $controller = new PhpConfigController($this->createMock(PhpBinaryFinder::class), $recoveryManager, $this->createMock(LanguageProvider::class));
         $controller->setContainer($this->buildContainer());
 
         $request = new Request();
@@ -59,7 +62,7 @@ class PhpConfigControllerTest extends TestCase
     public function testSetConfigOnInstall(): void
     {
         $recoveryManager = $this->createMock(RecoveryManager::class);
-        $recoveryManager->method('getShopwareLocation')->willThrowException(new \RuntimeException('cannot find shopware'));
+        $recoveryManager->method('getMode')->willReturn('install');
 
         $controller = new PhpConfigController($this->createMock(PhpBinaryFinder::class), $recoveryManager, $this->createMock(LanguageProvider::class));
         $controller->setContainer($this->buildContainer());

--- a/Tests/Listener/InstallerLocaleListenerTest.php
+++ b/Tests/Listener/InstallerLocaleListenerTest.php
@@ -30,6 +30,7 @@ class InstallerLocaleListenerTest extends TestCase
             'en-US' => ['id' => 'en-US', 'label' => 'English (US)'],
             'en'    => ['id' => 'en-GB', 'label' => 'English (UK)'],
             'de'    => ['id' => 'de-DE', 'label' => 'Deutsch'],
+            'es-ES' => ['id' => 'es-ES', 'label' => 'Español'],
         ]);
 
         $listener = new InstallerLocaleListener($languageProvider);
@@ -102,6 +103,38 @@ class InstallerLocaleListenerTest extends TestCase
         yield 'read language from session' => [
             $request,
             'de',
+        ];
+
+        $request = new Request(['language' => 'en-GB']);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        yield 'strips region tag to a supported base language' => [
+            $request,
+            'en',
+        ];
+
+        $request = new Request(['language' => 'en-US']);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        yield 'prefers an exact region match over the stripped base language' => [
+            $request,
+            'en-US',
+        ];
+
+        $request = new Request(['language' => 'es-ES']);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        yield 'matches a region-only language by its exact tag' => [
+            $request,
+            'es-ES',
+        ];
+
+        $request = new Request(['language' => 'es-MX']);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        yield 'region-only language is not mapped from a different region and falls back' => [
+            $request,
+            'en-US',
         ];
     }
 

--- a/Tests/Services/RecoveryManagerTest.php
+++ b/Tests/Services/RecoveryManagerTest.php
@@ -35,6 +35,72 @@ class RecoveryManagerTest extends TestCase
         static::assertSame(\dirname($fileName), $recoveryManager->getProjectDir());
     }
 
+    #[BackupGlobals(true)]
+    public function testGetInstallTargetDirInsidePublicReturnsParent(): void
+    {
+        $recoveryManager = new RecoveryManager();
+
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('shopware', true);
+        $fs->mkdir($tmpDir . '/public');
+
+        $_SERVER['SCRIPT_FILENAME'] = $tmpDir . '/public/shopware-installer.phar.php';
+        $fs->touch($_SERVER['SCRIPT_FILENAME']);
+
+        // PHAR sits in public/ → install into the parent (documented docroot=public/).
+        static::assertSame(realpath($tmpDir), $recoveryManager->getInstallTargetDir());
+
+        $fs->remove($tmpDir);
+    }
+
+    #[BackupGlobals(true)]
+    public function testGetInstallTargetDirOutsidePublicReturnsProjectDir(): void
+    {
+        $recoveryManager = new RecoveryManager();
+
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('shopware', true);
+        $fs->mkdir($tmpDir);
+
+        $_SERVER['SCRIPT_FILENAME'] = $tmpDir . '/shopware-installer.phar.php';
+        $fs->touch($_SERVER['SCRIPT_FILENAME']);
+
+        // PHAR at the project root → install right here (legacy docroot=project root).
+        static::assertSame(realpath($tmpDir), $recoveryManager->getInstallTargetDir());
+
+        $fs->remove($tmpDir);
+    }
+
+    #[BackupGlobals(true)]
+    public function testGetModeReturnsUpdateForExistingShopware(): void
+    {
+        $recoveryManager = new RecoveryManager();
+
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('shopware', true);
+        $fs = new Filesystem();
+        $this->prepareShopware($fs, $tmpDir);
+
+        static::assertSame('update', $recoveryManager->getMode());
+
+        $fs->remove($tmpDir);
+    }
+
+    #[BackupGlobals(true)]
+    public function testGetModeReturnsInstallWhenNoShopware(): void
+    {
+        $recoveryManager = new RecoveryManager();
+
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('shopware', true);
+        $fs->mkdir($tmpDir);
+        $_SERVER['SCRIPT_FILENAME'] = $tmpDir . '/shopware-installer.phar.php';
+        $fs->touch($_SERVER['SCRIPT_FILENAME']);
+
+        static::assertSame('install', $recoveryManager->getMode());
+
+        $fs->remove($tmpDir);
+    }
+
     public function testGetShopwareLocationReturnsFalseMissingShopware(): void
     {
         $recoveryManager = new RecoveryManager();

--- a/Twig/InstallerExtension.php
+++ b/Twig/InstallerExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\WebInstaller\Twig;
+
+use Shopware\WebInstaller\Services\StepProvider;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Exposes the data-driven stepper to the layout via `installer_steps()`, reading
+ * the current route and the `installerMode` session flag so no controller has to
+ * pass the navigation explicitly.
+ *
+ * @internal
+ *
+ * @phpstan-import-type Step from StepProvider
+ */
+class InstallerExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly StepProvider $stepProvider,
+    ) {}
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('installer_steps', $this->getSteps(...)),
+        ];
+    }
+
+    /**
+     * @return list<Step>
+     */
+    public function getSteps(): array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            return $this->stepProvider->getSteps('install', null);
+        }
+
+        $mode = 'install';
+        if ($request->hasSession() && $request->getSession()->has('installerMode')) {
+            $mode = (string) $request->getSession()->get('installerMode');
+        }
+
+        $route = $request->attributes->get('_route');
+
+        return $this->stepProvider->getSteps($mode, \is_string($route) ? $route : null);
+    }
+}


### PR DESCRIPTION
Install and update assumed the docroot was the project root, while the documentation and the Administration both serve the shop from `public/`. This aligns the guided flow with that layout and fixes a few issues found along the way:

- The installer installs into the parent directory when it runs from `public/`, and the post-install hand-off targets the shop root in both layouts.
- The updater shows only the steps that run in update mode, resolved from the filesystem on the first screen.
- The command log streams live instead of appearing once a step has finished.
- A `language` passed by the Administration falls back to its base language when the exact region is not supported.

Fixes https://github.com/shopware/shopware/issues/13828