### PR TITLE
fix(composer): unblock older Shopware installations after dompdf advisories

### DIFF
--- a/Services/ProjectComposerJsonUpdater.php
+++ b/Services/ProjectComposerJsonUpdater.php
@@ -14,13 +14,18 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class ProjectComposerJsonUpdater
 {
+    /**
+     * Shopware is not affected because only authenticated administration users can manipulate input rendered by dompdf.
+     *
+     * @var array<string, string>
+     */
     private const DOMPDF_ADVISORIES = [
-        'PKSA-cv56-2228-pzr6',
-        'PKSA-6r8f-nxsb-67bq',
-        'PKSA-gh7h-hhy4-byg7',
-        'PKSA-mwt3-h9tv-kx78',
-        'PKSA-hp6n-n4kz-21wk',
-        'PKSA-mckv-s5hg-868k',
+        'CVE-2026-59943' => 'https://github.com/advisories/GHSA-j8qw-6jw8-r297',
+        'CVE-2026-59942' => 'https://github.com/advisories/GHSA-f5gf-2cj8-52g2',
+        'CVE-2026-59941' => 'https://github.com/advisories/GHSA-8hg6-c449-896m',
+        'CVE-2026-56722' => 'https://github.com/advisories/GHSA-cx96-42px-69fm',
+        'CVE-2026-55555' => 'https://github.com/advisories/GHSA-7x2p-4jvh-6384',
+        'CVE-2026-55554' => 'https://github.com/advisories/GHSA-wvh6-f5jh-8gw4',
     ];
 
     public function __construct(private readonly HttpClientInterface $httpClient) {}
@@ -93,14 +98,14 @@ class ProjectComposerJsonUpdater
             }
         }
 
-        foreach (self::DOMPDF_ADVISORIES as $advisory) {
+        foreach (self::DOMPDF_ADVISORIES as $advisory => $link) {
             if (array_key_exists($advisory, $ignoredAdvisories)) {
                 continue;
             }
 
             $ignoredAdvisories[$advisory] = [
                 'apply' => 'block',
-                'reason' => 'Required to install or update Shopware versions that require dompdf below 3.1.6.',
+                'reason' => 'Shopware is not affected because only authenticated administration users can manipulate input rendered by dompdf. See ' . $link,
             ];
         }
 

--- a/Services/ProjectComposerJsonUpdater.php
+++ b/Services/ProjectComposerJsonUpdater.php
@@ -84,32 +84,34 @@ class ProjectComposerJsonUpdater
      */
     private function ignoreDompdfAdvisories(array $config): array
     {
-        /** @var list<string>|array<string, array{apply?: string, reason?: string}|string|null> $ignoredAdvisories */
-        $ignoredAdvisories = $config['config']['audit']['ignore'] ?? [];
+        /** @var list<string>|array<string, array{apply?: string, reason?: string}|string|null> $rawIgnoredAdvisories */
+        $rawIgnoredAdvisories = $config['config']['audit']['ignore'] ?? [];
+        /** @var array<string, array{apply?: string, reason?: string}|string|null> $normalizedIgnoredAdvisories */
+        $normalizedIgnoredAdvisories = [];
 
-        if (array_is_list($ignoredAdvisories)) {
-            $ignoredAdvisoryIds = $ignoredAdvisories;
-            $ignoredAdvisories = [];
-
-            foreach ($ignoredAdvisoryIds as $ignoredAdvisory) {
+        // Normalize input so advisories can always be looked up by array key.
+        if (array_is_list($rawIgnoredAdvisories)) {
+            foreach ($rawIgnoredAdvisories as $ignoredAdvisory) {
                 if (\is_string($ignoredAdvisory)) {
-                    $ignoredAdvisories[$ignoredAdvisory] = null;
+                    $normalizedIgnoredAdvisories[$ignoredAdvisory] = null;
                 }
             }
+        } else {
+            $normalizedIgnoredAdvisories = $rawIgnoredAdvisories;
         }
 
         foreach (self::DOMPDF_ADVISORIES as $advisory => $link) {
-            if (array_key_exists($advisory, $ignoredAdvisories)) {
+            if (array_key_exists($advisory, $normalizedIgnoredAdvisories)) {
                 continue;
             }
 
-            $ignoredAdvisories[$advisory] = [
+            $normalizedIgnoredAdvisories[$advisory] = [
                 'apply' => 'block',
                 'reason' => 'Shopware is not affected because only authenticated administration users can manipulate input rendered by dompdf. See ' . $link,
             ];
         }
 
-        $config['config']['audit']['ignore'] = $ignoredAdvisories;
+        $config['config']['audit']['ignore'] = $normalizedIgnoredAdvisories;
 
         return $config;
     }

--- a/Services/ProjectComposerJsonUpdater.php
+++ b/Services/ProjectComposerJsonUpdater.php
@@ -14,6 +14,15 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class ProjectComposerJsonUpdater
 {
+    private const DOMPDF_ADVISORIES = [
+        'PKSA-cv56-2228-pzr6',
+        'PKSA-6r8f-nxsb-67bq',
+        'PKSA-gh7h-hhy4-byg7',
+        'PKSA-mwt3-h9tv-kx78',
+        'PKSA-hp6n-n4kz-21wk',
+        'PKSA-mckv-s5hg-868k',
+    ];
+
     public function __construct(private readonly HttpClientInterface $httpClient) {}
 
     public function update(string $file, string $latestVersion): void
@@ -58,8 +67,46 @@ class ProjectComposerJsonUpdater
 
         $composerJson = $this->ensureConflictsRepository($composerJson);
         $composerJson = $this->configureRepositories($composerJson);
+        $composerJson = $this->ignoreDompdfAdvisories($composerJson);
 
         file_put_contents($file, json_encode($composerJson, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @param array<mixed> $config
+     *
+     * @return array<mixed>
+     */
+    private function ignoreDompdfAdvisories(array $config): array
+    {
+        /** @var list<string>|array<string, array{apply?: string, reason?: string}|string|null> $ignoredAdvisories */
+        $ignoredAdvisories = $config['config']['audit']['ignore'] ?? [];
+
+        if (array_is_list($ignoredAdvisories)) {
+            $ignoredAdvisoryIds = $ignoredAdvisories;
+            $ignoredAdvisories = [];
+
+            foreach ($ignoredAdvisoryIds as $ignoredAdvisory) {
+                if (\is_string($ignoredAdvisory)) {
+                    $ignoredAdvisories[$ignoredAdvisory] = null;
+                }
+            }
+        }
+
+        foreach (self::DOMPDF_ADVISORIES as $advisory) {
+            if (array_key_exists($advisory, $ignoredAdvisories)) {
+                continue;
+            }
+
+            $ignoredAdvisories[$advisory] = [
+                'apply' => 'block',
+                'reason' => 'Required to install or update Shopware versions that require dompdf below 3.1.6.',
+            ];
+        }
+
+        $config['config']['audit']['ignore'] = $ignoredAdvisories;
+
+        return $config;
     }
 
     private function getVersion(string $latestVersion): string

--- a/Tests/Services/ProjectComposerJsonUpdaterTest.php
+++ b/Tests/Services/ProjectComposerJsonUpdaterTest.php
@@ -82,24 +82,28 @@ class ProjectComposerJsonUpdaterTest extends TestCase
         $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
         $ignoredAdvisories = $composerJson['config']['audit']['ignore'];
 
+        static::assertIsArray($ignoredAdvisories);
         static::assertArrayHasKey('GHSA-existing-advisory', $ignoredAdvisories);
         static::assertNull($ignoredAdvisories['GHSA-existing-advisory']);
         unset($ignoredAdvisories['GHSA-existing-advisory']);
 
-        static::assertSame(array_fill_keys(
-            [
-                'PKSA-cv56-2228-pzr6',
-                'PKSA-6r8f-nxsb-67bq',
-                'PKSA-gh7h-hhy4-byg7',
-                'PKSA-mwt3-h9tv-kx78',
-                'PKSA-hp6n-n4kz-21wk',
-                'PKSA-mckv-s5hg-868k',
-            ],
-            [
+        $expectedAdvisories = [
+            'CVE-2026-59943' => 'https://github.com/advisories/GHSA-j8qw-6jw8-r297',
+            'CVE-2026-59942' => 'https://github.com/advisories/GHSA-f5gf-2cj8-52g2',
+            'CVE-2026-59941' => 'https://github.com/advisories/GHSA-8hg6-c449-896m',
+            'CVE-2026-56722' => 'https://github.com/advisories/GHSA-cx96-42px-69fm',
+            'CVE-2026-55555' => 'https://github.com/advisories/GHSA-7x2p-4jvh-6384',
+            'CVE-2026-55554' => 'https://github.com/advisories/GHSA-wvh6-f5jh-8gw4',
+        ];
+
+        static::assertSame(array_keys($expectedAdvisories), array_keys($ignoredAdvisories));
+
+        foreach ($expectedAdvisories as $cve => $link) {
+            static::assertSame([
                 'apply' => 'block',
-                'reason' => 'Required to install or update Shopware versions that require dompdf below 3.1.6.',
-            ]
-        ), $ignoredAdvisories);
+                'reason' => 'Shopware is not affected because only authenticated administration users can manipulate input rendered by dompdf. See ' . $link,
+            ], $ignoredAdvisories[$cve]);
+        }
     }
 
     public function testUpdateWithRC(): void

--- a/Tests/Services/ProjectComposerJsonUpdaterTest.php
+++ b/Tests/Services/ProjectComposerJsonUpdaterTest.php
@@ -43,7 +43,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.4.18.0'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -61,6 +61,47 @@ class ProjectComposerJsonUpdaterTest extends TestCase
         );
     }
 
+    public function testUpdateIgnoresDompdfAdvisoriesForDependencyBlocking(): void
+    {
+        file_put_contents($this->json, json_encode([
+            'require' => [
+                'shopware/core' => '1.2.3',
+            ],
+            'config' => [
+                'audit' => [
+                    'ignore' => ['GHSA-existing-advisory'],
+                ],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        (new ProjectComposerJsonUpdater(new MockHttpClient([$this->getEmptyVersionsResponse()])))->update(
+            $this->json,
+            '6.4.18.0'
+        );
+
+        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $ignoredAdvisories = $composerJson['config']['audit']['ignore'];
+
+        static::assertArrayHasKey('GHSA-existing-advisory', $ignoredAdvisories);
+        static::assertNull($ignoredAdvisories['GHSA-existing-advisory']);
+        unset($ignoredAdvisories['GHSA-existing-advisory']);
+
+        static::assertSame(array_fill_keys(
+            [
+                'PKSA-cv56-2228-pzr6',
+                'PKSA-6r8f-nxsb-67bq',
+                'PKSA-gh7h-hhy4-byg7',
+                'PKSA-mwt3-h9tv-kx78',
+                'PKSA-hp6n-n4kz-21wk',
+                'PKSA-mckv-s5hg-868k',
+            ],
+            [
+                'apply' => 'block',
+                'reason' => 'Required to install or update Shopware versions that require dompdf below 3.1.6.',
+            ]
+        ), $ignoredAdvisories);
+    }
+
     public function testUpdateWithRC(): void
     {
         (new ProjectComposerJsonUpdater(new MockHttpClient([$this->getEmptyVersionsResponse()])))->update(
@@ -68,7 +109,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.4.18.0-rc1'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -98,7 +139,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
 
         unset($_SERVER['SW_RECOVERY_NEXT_VERSION']);
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -129,7 +170,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
 
         unset($_SERVER['SW_RECOVERY_NEXT_VERSION']);
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -160,7 +201,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
 
         unset($_SERVER['SW_RECOVERY_NEXT_VERSION']);
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -193,7 +234,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.6.0.0'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -227,7 +268,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.7.0.0'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -260,7 +301,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.6.0.0'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -294,7 +335,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.2.0.0'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -328,7 +369,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             '6.4.0.0'
         );
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -369,7 +410,7 @@ class ProjectComposerJsonUpdaterTest extends TestCase
 
         unset($_SERVER['SW_RECOVERY_NEXT_VERSION']);
 
-        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+        $composerJson = $this->readComposerJsonWithoutDompdfAdvisories();
 
         static::assertSame(
             [
@@ -496,6 +537,26 @@ class ProjectComposerJsonUpdaterTest extends TestCase
             ],
             $composerJson['repositories']
         );
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function readComposerJsonWithoutDompdfAdvisories(): array
+    {
+        $composerJson = json_decode((string) file_get_contents($this->json), true, 512, \JSON_THROW_ON_ERROR);
+
+        unset($composerJson['config']['audit']['ignore']);
+
+        if ($composerJson['config']['audit'] === []) {
+            unset($composerJson['config']['audit']);
+        }
+
+        if ($composerJson['config'] === []) {
+            unset($composerJson['config']);
+        }
+
+        return $composerJson;
     }
 
     private function getEmptyVersionsResponse(): MockResponse


### PR DESCRIPTION
### 1. Why is this change necessary?

Composer 2.9 refuses to resolve older Shopware versions that require `dompdf/dompdf` below 3.1.6 because six recently published CVEs block dependency resolution. This prevents the web installer from running `composer install` or `composer update` for those versions.

### 2. What does this change do, exactly?

- Adds the six Dompdf CVE identifiers to the generated project `composer.json` before install or update.
- Limits each exception to dependency blocking, so `composer audit` continues to report the advisories.
- Links every exception to its GitHub advisory and documents that Shopware is not affected because only authenticated administration users can manipulate input rendered by Dompdf.
- Preserves existing project advisory ignores, including list-form configurations.

### 3. Describe each step to reproduce the issue or behaviour.

1. Resolve a project requiring `dompdf/dompdf:3.1.4` with Composer 2.9.5.
2. Without this change, Composer rejects the version because of the six security advisories.
3. Run the project Composer JSON updater and resolve dependencies again.
4. Composer now resolves the dependencies and still reports all six findings for auditing.

Verified with:

- PHPUnit: 98 tests, 290 assertions
- PHPStan
- PHP CS Fixer
- A Composer 2.9.5 dry-run resolving `dompdf/dompdf:3.1.4`

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
